### PR TITLE
Improve usability in user flows when the default SIJS<->UTF8 encoding is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Examples:
       sjisunzip --find_best_target SomeZipThatDidntWorkWithTheAboveSteps.zip
       
   Unusual Case: Same case as above but --find_best_target didn't work
-      sjisunzip --all_sources "C:\tmp\iƒeƒLƒXƒgƒtƒ@ƒCƒ‹j.zip"
+      sjisunzip --all_sources "C:\tmp\iƒeƒLƒXƒgƒtƒ@ƒCƒ‹j.zip"
       sjisunzip -s:<pick_a_value_from_the_output_of_the_previous_step> SomeZipFileEncodedWithEncoding1234.zip
       
-  Unusual Case: Fixing a folder you unzipped when you don't have the original zip anymore
-      sjisunzip -s:65001 -t:932 SomeFolderYouScrewedUpBecauseItWasZippedWithShiftJisAndYouAlreadyUnzippedItAsUTF8
-      sjisunzip -s:932 -t:65001 SomeFolderYouScrewedUpBecauseItWasZippedWithShiftJisAndYouAlreadyUnzippedItAsUTF8
+  Unusual Case: Fixing a folder with bad file names. Presumably, the contents of a zip file you already unzipped before,
+                which now has messed up file names, but you don't have the original zip anymore and you're desperate
+      sjisunzip -s:65001 -t:932 YourSpecialFolder       -- put the file names back into Shift-JIS, from your mangled UTF-8
+      sjisunzip -s:932 -t:65001 YourSpecialFolder       -- properly translate the file from Shift-JIS to UTF-8 this time
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-sjisunzip
-=========
+# This is a Fork of kjerk's "sjisunzip" utility.
 
-This is a pretty braindead command line utility that simply forces the encoding to the right values to extract a Shift JIS encoded zip file ('[Code page 932](http://en.wikipedia.org/wiki/Code_page_932)') on a western/ansi encoding system.
+[See kjerk's original version here](https://github.com/kjerk/sjisunzip)
 
-[Download Here](https://github.com/kjerk/sjisunzip/releases)
+# Basic Usage
+
+If you've attempted to unzip a file that was created on a Japanese computer, you might see files with completely garbled text.
+
+In some cases, this might make the files unusuable (eg. If the contents of the files contain the names of other files, those references won't work anymore)
+
+
+This can happen because the original file was created on a machine that has one default "encoding", and you've tried to unzip it on your own machine which has a different default "encoding", which gives you bad results.
+
+Use this utility to unzip your file, using an appropriate encoding translation.
 
 ```
 Usage:
@@ -15,22 +23,22 @@ Examples:
   sjisunzip aFile.zip MyNewFolder
 ```
 
-You can also just drop a zip file onto the program since that'll pass it as the first argument and the contents will be extracted in the same directory.
+# Advanced Usage
 
-If you've ever received a zip file from a friend, or the wrong damn gnu mirror or whatever that passed through Japan then you've probably seen garbled filenames
-![example_1](https://cloud.githubusercontent.com/assets/2738686/5326938/37acc0de-7ce7-11e4-8259-06ef8b1f43a8.jpg)
----
+```
+Examples:
+   sjisunzip SomeZipThatDidntWorkWithTheAboveSteps.zip --find_best_target
+   sjisunzip SomeZipFileEncodedWithEncoding1234.zip -s:1234
+   sjisunzip NothingElseIsWorkingWithThisZipFile.zip --all_sources -p
+```
 
-Well this program forces the opened zip to the correct encoding then extracts the file to a more reasonable UTF encoding.
-![example_2](https://cloud.githubusercontent.com/assets/2738686/5326978/712d7e50-7ce9-11e4-8f18-c885afc51055.jpg)
----
+In some less common cases, the options above may not be enough to fix your file names. This is because we have to assume what encoding the file made with, and we may have guessed wrong.
 
-You can even just reencode the zip file to a less busted-ass one so you don't have this creeping horror issue in the future
-![example_3](https://cloud.githubusercontent.com/assets/2738686/5326937/37ab2878-7ce7-11e4-9655-61b92a2b680d.jpg)
----
+If your folder still contains the wrong file names, try the `--find_best_target` command ling option, which will attempt to decode the target files with all the encoders available on the user's machine, rate the results, and then commit the operation using the "best" version. Useful for when the default UTF8 doesn't return correct results
 
-The filenames and paths should be untangled when done.
-![example_4](https://cloud.githubusercontent.com/assets/2738686/5326940/37af9d72-7ce7-11e4-8ee2-3a9d11c6e669.jpg)
----
+If nothing else is working, you can use the `--all_sources` command line option, as a way to print out all the encodings available on your machine as well as some information about the sjisunzip's "score" for each encoding. You can then use the `-s:` command line option to try out one of those encodings as the "source encoding" (the encoding that you think the file was made with
 
-Bonus fact: When this type of transitive corruption occurs, the output characters are called [Mojibake](http://en.wikipedia.org/wiki/Mojibake). That's almost cute enough to not be awful anymore.
+For power users, you can also use `-t:` as the "Target encoding" (the encoding that you want to write the file to)
+
+The command line option `-p` causes the program to halt upon completion, which can be useful for vieweing the output if you're running the script through a process where the window automatically closes when the program exits (such as if you set the program up as a "send to" windows target)
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage:
   sjisunzip someFolderContainingFilesWithBadNames
   
 Examples:
-  sjisunzip aFile.zip
+  sjisunzip --find_best_target aFile.zip
   sjisunzip aFile.zip MyNewFolder
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ Flags:
       -r                  Instead of unzipping to a folder, make a new zip file with UTF8 uncoding, named {filename}_utf8.zip,
                           which you should then be able to open with any standard zip program without naming problems
       --find_best_target  Compares the results of different target encodings to try to find the best results.
-      -s:<number>         Specify an override source encoding. Default is 932 (Shift JIS, AKA Windows-932, AKA CP932, AKA Windows-31J)
-                          use --all_sources to find a good source encoding
-      -t:<number>         Specify an override target encoding. Default is 65001 (UTF8)
+      -s:<number>         Specify an override source encoding. (What the file was created with)
+                               Default is 932 (Shift JIS, AKA Windows-932, AKA CP932, AKA Windows-31J)
+      -t:<number>         Specify an override target encoding. (What you the new file to be encoded with)
+                               Default is 65001 (UTF8)
                           using --find_best_target causes this parameter to be ignored
+      --all_sources       Special utility to help with -s command line option. Does not create a new file or folder. Instead,
+                          takes your input file, runs it through the encoders available on your machine, and prints out a
+			  list of the encoders along with a score representing how likely it is that the encoder was used to
+			  generate the file.
       -p                  pause on exit
       
 Usage:
-			sjisunzip some_folder_with_corrupt_filenames
+      sjisunzip some_folder_with_corrupt_filenames
       sjisunzip --all_sources someText [outputFile.txt]
           Attempts to use different source encoding schemes to decode the text, prints the output to a given file
           

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Use this utility to unzip your file, using an appropriate encoding translation.
 
 ```
 Usage:
-  sjisunzip someFile.zip [toFolder]
-  sjisunzip [-r] someFile.zip
-    -r: Recode file to {filename}_utf8.zip
+  sjisunzip [flags] someFile.zip [toFolder]
+  sjisunzip someFolderContainingFilesWithBadNames
+  
 Examples:
   sjisunzip aFile.zip
   sjisunzip aFile.zip MyNewFolder
@@ -26,11 +26,35 @@ Examples:
 # Advanced Usage
 
 ```
+Flags:
+      -r                  Instead of unzipping to a folder, make a new zip file with UTF8 uncoding, named {filename}_utf8.zip,
+                          which you should then be able to open with any standard zip program without naming problems
+      --find_best_target  Compares the results of different target encodings to try to find the best results.
+      -s:<number>         Specify an override source encoding. Default is 932 (Shift JIS, AKA Windows-932, AKA CP932, AKA Windows-31J)
+                          use --all_sources to find a good source encoding
+      -t:<number>         Specify an override target encoding. Default is 65001 (UTF8)
+                          using --find_best_target causes this parameter to be ignored
+      -p                  pause on exit
+      
+Usage:
+			sjisunzip some_folder_with_corrupt_filenames
+      sjisunzip --all_sources someText [outputFile.txt]
+          Attempts to use different source encoding schemes to decode the text, prints the output to a given file
+          
+      
 Examples:
-   sjisunzip SomeZipThatDidntWorkWithTheAboveSteps.zip --find_best_target
-   sjisunzip SomeZipFileEncodedWithEncoding1234.zip -s:1234
-   sjisunzip NothingElseIsWorkingWithThisZipFile.zip --all_sources -p
+  Unusual Case: Unzip a file that doesn't seem to have been encoding with Shift JIS (default sjisunzip didn't work)
+      sjisunzip --find_best_target SomeZipThatDidntWorkWithTheAboveSteps.zip
+      
+  Unusual Case: Same case as above but --find_best_target didn't work
+      sjisunzip --all_sources "C:\tmp\iƒeƒLƒXƒgƒtƒ@ƒCƒ‹j.zip"
+      sjisunzip -s:<pick_a_value_from_the_output_of_the_previous_step> SomeZipFileEncodedWithEncoding1234.zip
+      
+  Unusual Case: Fixing a folder you unzipped when you don't have the original zip anymore
+      sjisunzip -s:65001 -t:932 SomeFolderYouScrewedUpBecauseItWasZippedWithShiftJisAndYouAlreadyUnzippedItAsUTF8
+      sjisunzip -s:932 -t:65001 SomeFolderYouScrewedUpBecauseItWasZippedWithShiftJisAndYouAlreadyUnzippedItAsUTF8
 ```
+
 
 In some less common cases, the options above may not be enough to fix your file names. This is because we have to assume what encoding the file made with, and we may have guessed wrong.
 

--- a/SjisUnzip/SjisUnzipApp.cs
+++ b/SjisUnzip/SjisUnzipApp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -11,58 +11,247 @@ namespace SjisUnzip
 {
 	public class SjisUnzipApp
 	{
-		private readonly Encoding sjisEncoding = Encoding.GetEncoding(932);
+        protected const int sjisEncoding = 932; // Windows-932, AKA CP932, AKA Windows-31J, AKA "extended variant of Shift JIS"
 
-		public void Main(string[] args)
-		{
-			var recode = args.Any((s) => s.Equals("-r"));
+        bool mbRecode, mbVerbose, mbAllSourceEncodings, mbFindTargetEncoding, mbPauseOnExit;
+        Encoding mSourceEncoding, mTargetEncoding;
+        string mIn, mOut;
+        bool mError = false;
+        private bool ParseFlags(ref string[] args)
+        {
+            mbRecode = args.Any((s) => s.Equals("-r"));
+            mbVerbose = args.Any((s) => s.Equals("-v"));
+            mbPauseOnExit = args.Any((s) => s.Equals("-p"));
+            mbAllSourceEncodings = args.Any((s) => s.Equals("--all_sources"));
+            mbFindTargetEncoding = args.Any((s) => s.Equals("--find_best_target"));
 
-			if (recode && args.Length == 2)
-			{
-				args = args.Where((arg) => arg != "-r").ToArray();
-				if (args.Length > 0 && File.Exists(args[0]))
-				{
-					recodeFile(args[0]);
-				}
-			}
-			else if (args.Length == 1 && Directory.Exists(args[0]))
-			{
-				recodeCorruptFilenames(args[0], true);
-			}
-			else if (args.Length == 1 && File.Exists(args[0]) && args[0].EndsWith(".zip", true, CultureInfo.CurrentCulture))
-			{
-				extractSjisZip(args[0]);
-			}
-			else if (args.Length == 2 && File.Exists(args[0]) && args[0].EndsWith(".zip", true, CultureInfo.CurrentCulture))
-			{
-				var folderPath = Path.GetDirectoryName(args[0]);
-				var newFolderPath = Path.Combine(folderPath, args[1]);
-				Directory.CreateDirectory(newFolderPath);
-				extractSjisZip(args[0], newFolderPath);
-			}
-			else
-			{
-				printUsage();
-			}
-		}
+            string useEncoding = args.FirstOrDefault((s) => s.StartsWith("-s:"));
+            int defaultEncoding = sjisEncoding;
+            if (useEncoding != null)
+            {
+                defaultEncoding = int.Parse(useEncoding.Substring(3));
+            }
+            mSourceEncoding = Encoding.GetEncoding(defaultEncoding);
+
+            useEncoding = args.FirstOrDefault((s) => s.StartsWith("-t:"));
+            defaultEncoding = Encoding.UTF8.CodePage;
+            if (useEncoding != null)
+            {
+                defaultEncoding = int.Parse(useEncoding.Substring(3));
+            }
+            mTargetEncoding = Encoding.GetEncoding(defaultEncoding);
+
+            if (args.Length != 1)
+            {
+                args = args.Where((arg) => !arg.StartsWith("-")).ToArray();
+            }
+
+            if (args.Length == 0)
+            {
+                return false;
+            }
+
+            mIn = args[0];
+            mOut = null;
+            if (args.Length > 1)
+                mOut = args[1];
+
+            args = null;
+
+            return true;
+        }
+
+        public void Main(string[] args)
+        {
+            if (ParseFlags(ref args))
+            {
+                try
+                {
+                    Run();
+                }
+                catch (Exception e)
+                {
+                    mError = true;
+                    e.ToString().wl();
+                    string wait = System.Console.ReadLine();
+                }
+            }
+            else
+            {
+                mError = true;
+            }
+
+            if (mError)
+            {
+                printUsage();
+                mbPauseOnExit = true;
+            }
+
+            if (mbPauseOnExit)
+                for (; ; ) { }
+        }
+
+        protected void Run()
+        {
+            int encodingScore = 0;
+            if (mbFindTargetEncoding)
+            {
+                List<ConversionInfo> results;
+                if (Directory.Exists(mIn))
+                {
+                    EncodingInfo sourceEncodingInfo = null;
+                    foreach (EncodingInfo ei in Encoding.GetEncodings())
+                    {
+                        if (ei.CodePage == mSourceEncoding.CodePage)
+                        {
+                            sourceEncodingInfo = ei;
+                            break;
+                        }
+                    }
+
+                    results = new List<ConversionInfo>();
+                    foreach (EncodingInfo targetEncodingInfo in Encoding.GetEncodings())
+                    {
+                        mTargetEncoding = targetEncodingInfo.GetEncoding();
+                        int newScore = 0;
+
+                        ActOnCorruptFilenames(mIn, true,
+                            fi => newScore += fi.Name.ReEncode(mSourceEncoding, mTargetEncoding).JapaneseScore(),
+                            di => newScore += di.Name.ReEncode(mSourceEncoding, mTargetEncoding).JapaneseScore());
+
+                        if (newScore != 0)
+                            results.Add(new ConversionInfo(sourceEncodingInfo, targetEncodingInfo, newScore));
+                    }
+                }
+                else
+                {
+                    string seed = mIn;
+                    if (File.Exists(mIn))
+                        seed = Path.GetFileNameWithoutExtension(mIn);
+                     results = FindMostLikelyConversions(seed);
+                }
+
+                ConversionInfo best = results.OrderBy(x => x.mScore).Last();
+                mSourceEncoding = best.mOriginal.GetEncoding();
+                mTargetEncoding = best.mTarget.GetEncoding();
+                encodingScore = best.mScore;
+            }
+
+            if (mbRecode)
+            {
+                if (File.Exists(mIn))
+                    recodeFile(mIn);
+                else
+                    mError = true;
+            }
+            else if (mbAllSourceEncodings)
+            {
+                IterateAllSourceEncodings();
+            }
+            else if (mOut == null)
+            {
+                if (Directory.Exists(mIn))
+                {
+                    ActOnCorruptFilenames(mIn, true,
+                        fi => fi.Rename(fi.Name.ReEncode(mSourceEncoding, mTargetEncoding)),
+                        di => di.Rename(di.Name.ReEncode(mSourceEncoding, mTargetEncoding)));
+                }
+                else if (File.Exists(mIn))
+                {
+                    if (mIn.EndsWith(".zip", true, CultureInfo.CurrentCulture))
+                        extractSjisZip(mIn);
+                    else
+                    {
+                        FileInfo fileInfo = new FileInfo(mIn);
+                        fileInfo.Rename(fileInfo.Name.ReEncode(mSourceEncoding, mTargetEncoding));
+                    }
+                }
+                else
+                    mError = true;
+            }
+            else if (File.Exists(mIn) && mIn.EndsWith(".zip", true, CultureInfo.CurrentCulture))
+            {
+                var folderPath = Path.GetDirectoryName(mIn);
+                var newFolderPath = Path.Combine(folderPath, mOut);
+                Directory.CreateDirectory(newFolderPath);
+                extractSjisZip(mIn, newFolderPath);
+            }
+            else
+                mError = true;
+
+            String.Format("Converted using {0} ({1}) => {2} ({3})", mSourceEncoding.HeaderName, mSourceEncoding.CodePage, mTargetEncoding.HeaderName, mTargetEncoding.CodePage).wl();
+            String.Format("({0} => {1})", mSourceEncoding.EncodingName, mTargetEncoding.EncodingName).wl();
+            if (mbFindTargetEncoding)
+                String.Format("(score: {0})", encodingScore).wl();
+        }
+
+        protected void IterateAllSourceEncodings()
+        {
+            string outDir = null;
+            string outFile = null;
+            if (mOut != null)
+            {
+                if (mOut.Contains("."))
+                    outFile = mOut;
+                else
+                    outDir = mOut;
+            }
+            else
+            {
+                if (File.Exists(mIn) || Directory.Exists(mIn))
+                {
+                    outFile = Path.Combine(Path.GetDirectoryName(mIn), Path.GetFileNameWithoutExtension(mIn) + "_encodings.txt");
+                    mIn = System.IO.Path.GetFileNameWithoutExtension(mIn);
+                }
+            }
+
+            if (outDir != null)
+            {
+                if (Directory.Exists(outDir))
+                    Directory.Delete(outDir);
+                Directory.CreateDirectory(outDir);
+            }
+
+            Encoding toEncoding = Encoding.Unicode;
+            using (FileStream outStream = outFile != null ? File.OpenWrite(outFile) : null)
+            {
+                StreamWriter sw = outStream != null ? new StreamWriter(outStream, toEncoding) : null;
+                foreach (EncodingInfo ei in Encoding.GetEncodings())
+                {
+                    Convert(mIn, ei.CodePage, toEncoding, outDir, sw);
+                }
+            }
+        }
 
 		static void printUsage()
 		{
 			"Usage: sjisunzip someFile.zip [toFolder]".wl();
-			"Usage: sjisunzip [-r] someFile.zip".wl();
+			"Usage: sjisunzip [flags] someFile.zip".wl();
 			"    -r: Recode file to {filename}_utf8.zip".wl();
 			"Usage: sjisunzip ./some_folder_with_corrupt_filenames".wl();
-			"Examples:".wl();
+            "Usage: sjisunzip --all_sources someText [outputFile.txt]".wl();
+            "         Attempts to use different source encoding schemes to decode the text, prints the output to a given file".wl();
+            "Flags:".wl();
+            "    --find_best_target  Compares the results of different target encodings to try to find the best results.".wl();
+            "    -s:<number>         Specify an override source encoding. Default is 932 (shift_jis).".wl();
+            "                        use --all_sources to find a good source encoding".wl();
+            "    -t:<number>         Specify an override target encoding. Default is 65001 (UTF8).".wl();
+            "                        using --find_best_target causes this parameter to be ignored".wl();
+            "    -p                  pause on exit".wl();
+            "".wl();
+            "Examples:".wl();
 			"    sjisunzip aFile.zip".wl();
 			"    sjisunzip aFile.zip MyNewFolder".wl();
-		}
+            "    sjisunzip -s:932 aFile.zip".wl();
+            "    sjisunzip -s:932 aFolder".wl();
+            "    sjisunzip --all_sources \"C:\\tmp\\iƒeƒLƒXƒgƒtƒ@ƒCƒ‹j.zip\"".wl();
+        }
 
 		private void extractSjisZip(string fileName, string toFolder = "./")
 		{
 			"Writing to folder {0}...".wl(toFolder);
 
-			using (var zipFile = new ZipArchive(new FileStream(fileName, FileMode.Open, FileAccess.Read), 
-				ZipArchiveMode.Read, false, Encoding.GetEncoding(932)))
+			using (var zipFile = new ZipArchive(new FileStream(fileName, FileMode.Open, FileAccess.Read), ZipArchiveMode.Read, false, mSourceEncoding))
 			{
 				zipFile.ExtractToDirectory(toFolder);
 			}
@@ -72,10 +261,10 @@ namespace SjisUnzip
 
 		private void recodeFile(string srcFile)
 		{
-			var zipFile = new ZipArchive(new FileStream(srcFile, FileMode.Open), ZipArchiveMode.Read, false, sjisEncoding);
-			var newFilePath = Path.Combine(Path.GetDirectoryName(srcFile), Path.GetFileNameWithoutExtension(srcFile) + "_utf8.zip");
+			var zipFile = new ZipArchive(new FileStream(srcFile, FileMode.Open), ZipArchiveMode.Read, false, mSourceEncoding);
+			var newFilePath = Path.Combine(Path.GetDirectoryName(srcFile), Path.GetFileNameWithoutExtension(srcFile) + "_" + mTargetEncoding.HeaderName + ".zip");
 
-			using (var newZip = new ZipArchive(new FileStream(newFilePath, FileMode.CreateNew), ZipArchiveMode.Create, false, Encoding.UTF8))
+			using (var newZip = new ZipArchive(new FileStream(newFilePath, FileMode.CreateNew), ZipArchiveMode.Create, false, mTargetEncoding))
 			{
 				foreach (var zipEntry in zipFile.Entries)
 				{
@@ -96,31 +285,124 @@ namespace SjisUnzip
 
 		readonly Func<char, bool> dirSeparatorComparator = c => c == Path.DirectorySeparatorChar;
 
-		private void recodeCorruptFilenames(string directoryPath, bool recurse)
+		private void ActOnCorruptFilenames(string directoryPath, bool recurse, Action<FileInfo> fileAction, Action<DirectoryInfo> dirAction)
 		{
 			var rootDir = new DirectoryInfo(directoryPath);
 			var dirs = rootDir.GetDirectories("*", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).ToList();
 			var files = rootDir.GetFiles("*", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
 
-			files.Where(fi => fi.Name.ContainsNonAscii() && !fi.Name.ContainsJapanese())
-				.ToList()
-				.ForEach(
-					fi => fi.Rename(fi.Name.DecodeMojibake())
-				);
+            try
+            {
+                files.Where(fi => fi.Name.ContainsNonAscii() && !fi.Name.ContainsJapanese())
+                    .ToList()
+                    .ForEach(fileAction);
+            }
+            catch (Exception ex)
+            {
+                ex.ToString().wl();
+                mError = true;
+            }
 			
 			// Sort reversed based on directory depth, rename deepest first and this won't rename a root before a leaf.
 			dirs.Sort((d2, d1) => d1.FullName.Count(dirSeparatorComparator).CompareTo(d2.FullName.Count(dirSeparatorComparator)));
 
-			dirs.Where(di => di.Name.ContainsNonAscii() && !di.Name.ContainsJapanese())
+            try
+            {
+                dirs.Where(di => di.Name.ContainsNonAscii() && !di.Name.ContainsJapanese())
 				.ToList()
-				.ForEach(
-					di => di.Rename(di.Name.DecodeMojibake())
-				);
+				.ForEach(dirAction);
+            }
+            catch (Exception ex)
+            {
+                ex.ToString().wl();
+                mError = true;
+            }
 
-			if (rootDir.Name.ContainsNonAscii() && !rootDir.Name.ContainsJapanese())
+            if (rootDir.Name.ContainsNonAscii() && !rootDir.Name.ContainsJapanese())
 			{
-				rootDir.Rename(rootDir.Name.DecodeMojibake());
+                dirAction.Invoke(rootDir);
 			}
-		}
-	}
+        }
+
+        struct ConversionInfo
+        {
+            public ConversionInfo(EncodingInfo original, EncodingInfo target, int score)
+            {
+                mScore = score;
+                mOriginal = original;
+                mTarget = target;
+            }
+
+            public int mScore;
+            public EncodingInfo mOriginal, mTarget;
+        }
+
+        static List<ConversionInfo> FindMostLikelyConversions(string str)
+        {
+            List<ConversionInfo> results = new List<ConversionInfo>();
+
+            string bestResult = str;
+            ConversionInfo result;
+            result.mScore = str.JapaneseScore();
+            result.mOriginal = null;
+            result.mTarget = null;
+
+            foreach (EncodingInfo originalEncodingInfo in Encoding.GetEncodings())
+            {
+                Encoding originalEncoding = originalEncodingInfo.GetEncoding();
+                foreach (EncodingInfo targetEncodingInfo in Encoding.GetEncodings())
+                {
+                    string testStr = str.ReEncode(originalEncoding, targetEncodingInfo.GetEncoding());
+                    int newScore = testStr.JapaneseScore();
+                    if (newScore != 0)
+                        results.Add(new ConversionInfo(originalEncodingInfo, targetEncodingInfo, newScore));
+                }
+            }
+
+            return results;
+        }
+
+        static void Convert(string str, int fromEncodingPage, Encoding to, string outDir, StreamWriter outFile)
+        {
+            string decoded = "CANNOT_DECODE";
+            string fromName = "NOT_SUPPORTED_ON_THIS_COMPUTER";
+            string fromHeaderName = string.Format("({0})", fromEncodingPage);
+            try
+            {
+                Encoding from = Encoding.GetEncoding(fromEncodingPage);
+                fromName = from.EncodingName;
+                decoded = str.Decode(from);
+            }
+            catch (Exception)
+            {
+            }
+
+            string outStr = String.Format("({0,6}){1,40}: {2}", fromEncodingPage, fromName, decoded);
+            outStr.wl();
+
+            if (outFile != null)
+            {
+                outFile.WriteLine(outStr);
+            }
+
+            if (outDir != null)
+            {
+                byte[] bytes = to.GetBytes(decoded);
+                string fileName = string.Format("({0}){1}_to_({2}){3}.txt", fromEncodingPage, fromHeaderName, to.WindowsCodePage, to.HeaderName);
+                try
+                {
+                    File.OpenWrite(outDir + "\\" + fileName).Write(bytes, 0, bytes.Count());
+                }
+                catch (Exception)
+                {
+                    try
+                    {
+                        fileName = string.Format("{0}_to_{1}.txt", fromEncodingPage, to.WindowsCodePage);
+                        File.OpenWrite(outDir + "\\" + fileName).Write(bytes, 0, bytes.Count());
+                    }
+                    catch (Exception) { }
+                }
+            }
+        }
+    }
 }

--- a/SjisUnzipTests/ExtensionTests.cs
+++ b/SjisUnzipTests/ExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -41,7 +41,7 @@ namespace SjisUnzipTests
 		[TestMethod]
 		public void TestDecodeMojibake()
 		{
-			var degarbled = textGarbled.DecodeMojibake();
+			var degarbled = textGarbled.Decode(sjisEncoding);
 			Assert.AreEqual(textCorrect, degarbled, "Degarbled text should be equivalent to the uncorrupted original.");
 		}
 


### PR DESCRIPTION
Add new command line option, --find_best_target, which will attempt to decode the target files with all the encoders available on the user's machine, rate the results, and then commit the operation using the "best" version. Useful for when the default UTF8 doesn't return correct results

Add new command line options, -s: and -t:, which can be used to allow the user to specify an override source and target encoding, respectively. For power users who don't like the magic nature of --find_best_target

Add new command line option, --all_sources, as a utility to help a user decide which encoder to use with the -s command line option

Add new command line option -p, which causes the program to halt upon completion, allowing the user the option to view any output, including errors or unhandled exceptions

Added try {} catch {} blocks around some file operations, to allow operations to continue to execute in the event that two file decodings end up resulting in the same name, causing one of the files to fail to be renamed (can happen more frequently when the source or target encoder was incorrect)